### PR TITLE
p08

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,124 @@
 name: CI
+
 on:
-  pull_request:
   push:
-    branches: [main]
+  pull_request:
+
 permissions:
   contents: read
+  packages: write
+
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
+    name: Lint & Format
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          cache: "pip"
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Lint & Format
+      - name: Quality gates
         run: |
           ruff check --output-format=github .
           black --check .
           isort --check-only .
+          pre-commit run --all-files
 
-      - name: Tests
-        run: pytest -q
+  tests:
+    name: Tests (${{ matrix.os }} / py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Pre-commit (all files)
-        run: pre-commit run --all-files
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Prepare reports directory
+        run: python -c "from pathlib import Path; Path('reports').mkdir(parents=True, exist_ok=True)"
+
+      - name: Pytest with coverage
+        run: >-
+          pytest -q --maxfail=1 --disable-warnings
+          --cov=app
+          --cov-report=xml:reports/coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml
+          --junitxml=reports/junit-${{ matrix.os }}-${{ matrix.python-version }}.xml
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.os }}-${{ matrix.python-version }}
+          path: reports
+          retention-days: 7
+
+  container_scan:
+    name: Container Build, Scan & Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs:
+      - lint
+      - tests
+    outputs:
+      ghcr_image: ${{ steps.push_image.outputs.image_ref }}
+    env:
+      IMAGE_LOCAL_TAG: recipe-box-ci:${{ github.sha }}
+      IMAGE_REPO: ${{ github.repository_owner }}/recipe-box
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Build runtime image
-        run: docker build --target runtime -t recipe-box-ci .
+        run: docker build --target runtime -t ${{ env.IMAGE_LOCAL_TAG }} .
+
+      - name: Capture image digest
+        run: |
+          docker image inspect ${{ env.IMAGE_LOCAL_TAG }} --format='{{.Id}}' > runtime-image.txt
+          cat runtime-image.txt
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Hadolint
         uses: hadolint/hadolint-action@v3.1.0
@@ -46,26 +126,79 @@ jobs:
           dockerfile: Dockerfile
           config: .hadolint.yaml
 
+      - name: Push image to GHCR
+        id: push_image
+        run: |
+          IMAGE_REPO_LC=$(echo "${IMAGE_REPO}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_REF="ghcr.io/${IMAGE_REPO_LC}:${GITHUB_SHA}"
+          docker tag "${IMAGE_LOCAL_TAG}" "${IMAGE_REF}"
+          docker push "${IMAGE_REF}"
+          echo "image_ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+          echo "${IMAGE_REF}" > ghcr-image.txt
+
       - name: Trivy scan (filesystem)
         id: trivy
         continue-on-error: true
         uses: aquasecurity/trivy-action@0.22.0
         with:
-          scan-type: "fs"
-          format: "table"
+          scan-type: fs
+          format: table
           exit-code: "1"
-          output: "trivy-fs.txt"
-          trivyignores: ".trivyignore"
+          output: trivy-fs.txt
+          trivyignores: .trivyignore
 
-      - name: Upload Trivy report
+      - name: Upload container artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: trivy-fs-report
-          path: trivy-fs.txt
+          name: container-security
+          path: |
+            runtime-image.txt
+            trivy-fs.txt
+            ghcr-image.txt
 
       - name: Fail if Trivy detected vulnerabilities
         if: steps.trivy.outcome == 'failure'
         run: |
           echo "Trivy reported HIGH/CRITICAL vulnerabilities"
           exit 1
+
+  ephemeral_verify:
+    name: Runtime Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    needs:
+      - container_scan
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull published image
+        run: docker pull ${{ needs.container_scan.outputs.ghcr_image }}
+
+      - name: Start container
+        run: >-
+          docker run -d --name recipe-box-${{ github.run_id }}
+          -p 8000:8000
+          ${{ needs.container_scan.outputs.ghcr_image }}
+
+      - name: Probe /health endpoint
+        run: |
+          for attempt in {1..10}; do
+            if curl -fsS http://127.0.0.1:8000/health; then
+              exit 0
+            fi
+            echo "Health check attempt ${attempt} failed; retrying..."
+            sleep 3
+          done
+          echo "Service failed to become healthy"
+          docker logs recipe-box-${GITHUB_RUN_ID} || true
+          exit 1
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f recipe-box-${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Recipe Box API
 
+[![CI](https://github.com/Cratone/HSE-DSO/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Cratone/HSE-DSO/actions/workflows/ci.yml)
+
 Менеджер рецептов с ингредиентами и безопасными контролями.
 
 ## Требования окружения

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ ruff==0.6.9
 black==24.8.0
 isort==5.13.2
 pre-commit==3.8.0
+coverage==7.6.4
+pytest-cov==5.0.0


### PR DESCRIPTION
## Контекст
closes #7 

## Что сделано
C1. 
<img width="842" height="391" alt="image" src="https://github.com/user-attachments/assets/e0b3eb43-e19d-4fad-b8e8-10c0537c97bb" />


C2. 
<img width="375" height="120" alt="image" src="https://github.com/user-attachments/assets/f8ef5331-f6fe-4abd-bd75-da95f652550f" />

<img width="803" height="624" alt="image" src="https://github.com/user-attachments/assets/e5b2c0c3-6f0a-4272-9443-76e8418573b3" />

C3. Workflow ограничивается встроенным GITHUB_TOKEN, которому через настройки выдано право packages: write
<img width="783" height="165" alt="image" src="https://github.com/user-attachments/assets/0ea8edfd-bd2c-4cfe-b460-0053d79c3af7" />

C4. https://github.com/Cratone/HSE-DSO/actions/runs/19645825638
<img width="2150" height="386" alt="image" src="https://github.com/user-attachments/assets/4654c642-cf1e-4562-a470-b567d4dd41c1" />


C5. Job ephemeral_verify тянет образ из GHCR, разворачивает его на runner’е, проверяет /health и удаляет контейнер. Таким образом, конвейер публикует реальный образ и подтверждает его готовность без внешнего стенда.
<img width="693" height="804" alt="image" src="https://github.com/user-attachments/assets/7b756a64-9b52-46f2-92e3-e44d251489b2" />


## Как проверял(а)
- [x] `ruff/black/isort` локально
- [x] `pytest -q` зелёный
- [x] `pre-commit run --all-files`
